### PR TITLE
fix return type

### DIFF
--- a/src/MessageGetterInterface.php
+++ b/src/MessageGetterInterface.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Phpolar\Validator;
 
+use Stringable;
+
 /**
  * Unifies validation configuration objects with a standard api.
  */
@@ -12,7 +14,7 @@ interface MessageGetterInterface
   /**
    * Provides validation messages.
    *
-   * @return string[]|Stringable[]
+   * @return (string|Stringable)[]
    */
   public function getMessages(): array;
 }


### PR DESCRIPTION
The typedoc declaration was not
using the fully qualified name for
Stringable.