### PR TITLE
feat(MessageGetterInterface): return a string instead of an array of …

### DIFF
--- a/src/MessageGetterInterface.php
+++ b/src/MessageGetterInterface.php
@@ -4,17 +4,13 @@ declare(strict_types=1);
 
 namespace PhpContrib\Validator;
 
-use Stringable;
-
 /**
  * Unifies validation configuration objects with a standard api.
  */
 interface MessageGetterInterface
 {
-  /**
-   * Provides validation messages.
-   *
-   * @return (string|Stringable)[]
-   */
-  public function getMessages(): array;
+    /**
+     * Provides a message that describes why the value is invalid.
+     */
+    public function getMessage(): string;
 }


### PR DESCRIPTION
…strings

Returning a single string provides more type safety then relying tooling to honor `string[]`.  Returning an array of strings is not as intuitive.

BREAKING CHANGE: Use `MessageGetterInterface::getMessage()` instead of `MessageGetterInterface::getMessages()`.